### PR TITLE
add a space after heading

### DIFF
--- a/_posts/2012-04-07-burnout.md
+++ b/_posts/2012-04-07-burnout.md
@@ -11,7 +11,7 @@ Low productivity caused me to try to compensate by working longer hours, routine
 
 It didn't work.
 
-##The symptoms
+## The symptoms
 
 After about two months of high pressure, I noticed the first symptoms; decreased productivity and concentration difficulties. At the time, I dismissed it as the normal ups and downs. Who hasn't had a bad monday? But the problems persisted.
 
@@ -25,7 +25,7 @@ Having realized I didn't feel fine, I started feeling all the pent up stress. Wh
 
 I usually run or walk to clear my head, and it normally works really well. Now, I felt just as bad when I came in from a long, brisk walk. I would constantly feel hurried, munching down my meals quickly, just because I felt stressed. I would sometimes feel like I would cry at any moment. I kept telling myself to pull myself together, but I could not.
 
-##The hard part
+## The hard part
 
 I knew this could not go on. I was hurting myself and the people who depended on me. I decided I needed to tell them how I really felt, rather than maintaining a façade.
 
@@ -33,7 +33,7 @@ That was hard.
 
 I was already avoiding contact by phone, and even email when I could. Coming forward and admitting weakness -- and in my mind at the time, letting everyone down -- felt incredibly embarrassing. So I wrote an email. I stared at it for a while, then sent it to everyone involved and went to bed.
 
-##Getting better
+## Getting better
 
 I received a genuinely supportive response from my "boss" and coworkers. (Thanks!) Without that, my recovery would have been a lot more difficult. I began by just not working when I felt too bad, or if I couldn't get anything done anyway. Even if the end result in terms of getting work done was the same, it makes a huge difference in knowing that it's OK. No one will be angry with me or disappointed. The difference was entirely inside my head, but it was necessary.
 
@@ -49,6 +49,6 @@ I spent my 4 weeks of vacation thinking about work as little as possible, and ca
 
 But I had some reservations; I would no longer try to compensate bad planning by working harder. And -- I believe -- most importantly; I would not let my sense of responsibility get to my head. 
 
-##So what?
+## So what?
 
 If I have helped anyone by sharing this experience, I'm very pleased. Be observant of stress related symptoms and take them seriously. I got away with a warning, but I know people around me who were not so lucky. One of them needed a 6 month period off and a change of jobs to recover. Another one hasn't fully recovered still over five years later. Take care.


### PR DESCRIPTION
not all markdown implementations need this, but it seems like this one does, since I don't see all of the headings on your page
