### PR TITLE
Fixed Mixed Content

### DIFF
--- a/_includes/JB/comments-providers/disqus
+++ b/_includes/JB/comments-providers/disqus
@@ -6,7 +6,7 @@
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>


### PR DESCRIPTION
When loading `https://geon.github.io/programming/2016/03/03/dsxyliea`, chrome errors with this:

```
dsxyliea:262 Mixed Content: The page at 'https://geon.github.io/programming/2016/03/03/dsxyliea' was loaded over HTTPS, but requested an insecure script 'http://geon.disqus.com/embed.js'. This request has been blocked; the content must be served over HTTPS.
(anonymous) @ dsxyliea:262
```

The fix is to simply change the script to load from the https link instead of the http link